### PR TITLE
Enable commenters to auto delete

### DIFF
--- a/StepFunctionCloudFormation.yaml
+++ b/StepFunctionCloudFormation.yaml
@@ -65,17 +65,6 @@ Resources:
                     }
                   },
                   {
-                    "StartAt": "userHasNotCommented",
-                    "States": {
-                      "userHasNotCommented": {
-                        "Type": "Task",
-                        "ResultPath": "$.deletionCriterionSatisfied",
-                        "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:userHasNotCommented",
-                        "End": true
-                      }
-                    }
-                  },
-                  {
                     "StartAt": "userHasNoJobs",
                     "States": {
                       "userHasNoJobs": {
@@ -88,13 +77,11 @@ Resources:
                   }
                 ]
               },
-
               "isAutoDeletionCriteriaSatisfied": {
                 "Type": "Task",
                 "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:isAutoDeletionCriteriaSatisfied",
                 "Next": "chooseAccountDeletionType"
               },
-
               "chooseAccountDeletionType": {
                 "Type": "Choice",
                 "Choices": [
@@ -110,7 +97,6 @@ Resources:
                   }
                 ]
               },
-
               "UnsubscribeFromAllMailingLists": {
                 "Type": "Task",
                 "InputPath": "$.credentials.stateMachineInput.CiphertextBlob",
@@ -119,23 +105,53 @@ Resources:
                 "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:unsubscribeEmails",
                 "Next": "DeleteUser"
               },
-
-              "AutoDeletion": {
-                "Type": "Pass",
+              "userHasNotCommented": {
+                "Type": "Task",
+                "ResultPath": "$.userHasNotCommented",
+                "OutputPath": "$",
+                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:userHasNotCommented",
+                "Next": "ChooseAutoDeletionType"
+              },
+              "anonymiseUsername": {
+                "Type": "Task",
+                "ResultPath": "$.userHasNotCommented",
+                "OutputPath": "$",
+                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:anonymiseUsername",
+                "Next": "waitFiveSeconds"
+              },
+              "waitFiveSeconds": {
+                "Type": "Wait",
+                "Seconds": 5,
                 "Next": "UnsubscribeFromAllMailingLists"
               },
-
+              "ChooseAutoDeletionType": {
+                "Type": "Choice",
+                "Choices": [
+                  {
+                    "Variable": "$.userHasNotCommented",
+                    "BooleanEquals": true,
+                    "Next": "UnsubscribeFromAllMailingLists"
+                  },
+                  {
+                    "Variable": "$.userHasNotCommented",
+                    "BooleanEquals": false,
+                    "Next": "anonymiseUsername"
+                  }
+                ]
+              },
+              "AutoDeletion": {
+                "Type": "Pass",
+                "Next": "userHasNotCommented"
+              },
               "DeleteUser": {
                 "Type": "Task",
                 "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:deleteUser",
                 "End": true
               },
-
               "ManualDeletion": {
                 "Type": "Pass",
                 "Next": "NotifyUserhelp"
               },
-
               "NotifyUserhelp": {
                 "Type": "Task",
                 "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:notifyUserhelp",
@@ -279,3 +295,17 @@ Resources:
             CLIENT_SECRET: !Ref etClientSecret
             CLIENT_ID: !Ref etClientId
             USERHELP_EMAIL: !Ref etUserhelpEmail
+
+  anonymiseUsername:
+      Type: "AWS::Lambda::Function"
+      Properties:
+        FunctionName: anonymiseUsername
+        Description: Sets the username and displayname to random alphanumeric string
+        Handler: "anonymiseUsername.handler"
+        Role: !Sub arn:aws:iam::${AWS::AccountId}:role/lambda_basic_execution
+        Code:
+          S3Bucket: !Ref lambdaCodeS3Bucket
+          S3Key: !Ref lambdaCodeS3Key
+        Runtime: "nodejs4.3"
+        MemorySize: "512"
+        Timeout: "20"

--- a/nodejs/anonymiseUsername.js
+++ b/nodejs/anonymiseUsername.js
@@ -1,0 +1,65 @@
+var AWS = require('aws-sdk');
+var http = require('https');
+var kms = new AWS.KMS();
+
+// http://stackoverflow.com/questions/1349404/generate-random-string-characters-in-javascript
+function generateRandomAlphanumericString(strlen) {
+    return Math.random().toString(36).substr(2,strlen);
+}
+
+function anonymiseUsername(decryptedInput) {
+    return new Promise((resolve, reject) => {
+        var options = {
+            host: 'idapi.theguardian.com',
+            path: '/user/me',
+            headers: {
+                'X-GU-ID-FOWARDED-SC-GU-U': decryptedInput.scGuCookie,
+                'X-GU-ID-Client-Access-Token': decryptedInput.clientAccessToken,
+                'Referer': 'https://theguardian.com',
+                'Content-Type': "application/json",
+            },
+            method: 'POST'
+        };
+
+        var randomUsername = generateRandomAlphanumericString(12);
+        var postData = JSON.stringify(
+            {
+                publicFields: {
+                    username: randomUsername,
+                    displayName: randomUsername
+                }
+            }
+        );
+
+        var request = http.request(options);
+
+        request.on('error', (networkError) => reject(networkError));
+
+        request.on('response', (response) => {
+            var responseData = '';
+
+            response.on('data', (chunk) => responseData += chunk);
+
+            response.on('end', () => {
+                try {
+                    resolve(JSON.parse(responseData));
+                } catch (error) {
+                    reject(error);
+                }
+            });
+
+        });
+
+        request.write(postData);
+        request.end();
+    });
+}
+
+exports.handler = (event, context, callback) => {
+    kms.decrypt({ CiphertextBlob: new Buffer(event.credentials.stateMachineInput.CiphertextBlob) }).promise()
+        .then((data) => {
+            const decryptedInput = JSON.parse(data.Plaintext.toString('utf8'));
+            anonymiseUsername(decryptedInput).then((result) => callback(null, true))
+        })
+        .catch((error) => callback(error))
+};

--- a/nodejs/deploy.sh
+++ b/nodejs/deploy.sh
@@ -24,5 +24,6 @@ aws lambda update-function-code --function-name userIsNotSubscriber --s3-bucket 
 aws lambda update-function-code --function-name isAutoDeletionCriteriaSatisfied --s3-bucket $S3_BUCKET --s3-key $S3_KEY
 aws lambda update-function-code --function-name notifyUserhelp --s3-bucket $S3_BUCKET --s3-key $S3_KEY
 aws lambda update-function-code --function-name deleteUser --s3-bucket $S3_BUCKET --s3-key $S3_KEY
+aws lambda update-function-code --function-name anonymiseUsername --s3-bucket $S3_BUCKET --s3-key $S3_KEY
 
 echo "Done."

--- a/nodejs/userHasNotCommented.js
+++ b/nodejs/userHasNotCommented.js
@@ -36,7 +36,7 @@ function userHasNotCommented(scGuCookie) {
 }
 
 exports.handler = (event, context, callback) => {
-    kms.decrypt({ CiphertextBlob: new Buffer(event.stateMachineInput.CiphertextBlob) }).promise()
+    kms.decrypt({ CiphertextBlob: new Buffer(event.credentials.stateMachineInput.CiphertextBlob) }).promise()
         .then((data) => {
             const decryptedInput = JSON.parse(data.Plaintext.toString('utf8'));
             userHasNotCommented(decryptedInput.scGuCookie).then((result) => callback(null, result));


### PR DESCRIPTION
This automates the current manual process of deleting commenters.

* Anonymises username by setting it to random alphanumeric string
* The [wait state](http://docs.aws.amazon.com/step-functions/latest/dg/awl-ref-states-wait.html) is necessary to give DAPI chance to update its database. (DAPI updates itself in response to SNS notification)