### PR TITLE
Remove argument and local variable having the same name

### DIFF
--- a/nodejs/isAutoDeletionCriteriaSatisfied.js
+++ b/nodejs/isAutoDeletionCriteriaSatisfied.js
@@ -8,10 +8,10 @@
  */
 
 exports.handler = (event, context, callback) => {
-    const criterionFailedIndex =
-        event.map((branchResult) => branchResult.deletionCriterion.satisfied).indexOf(false);
-
     try {
+        const criterionFailedIndex =
+            event.map((branchResult) => branchResult.deletionCriterion.satisfied).indexOf(false);
+
         if (criterionFailedIndex < 0) {
             callback(null, {
                 credentials: event[0],

--- a/nodejs/userIsNotMember.js
+++ b/nodejs/userIsNotMember.js
@@ -1,11 +1,10 @@
-var AWS = require('aws-sdk');
-var http = require('https');
-var kms = new AWS.KMS();
+const AWS = require('aws-sdk');
+const http = require('https');
+const kms = new AWS.KMS();
 
 function userIsNotMember(scGuCookie) {
     return new Promise((resolve, reject) => {
-
-        var options = {
+        const options = {
             host: 'members-data-api.theguardian.com',
             path: '/user-attributes/me/mma-membership',
             headers: {
@@ -14,27 +13,30 @@ function userIsNotMember(scGuCookie) {
         };
 
         function processResponse(response) {
-            var str = '';
+            var responseData = '';
 
-            response.on('data', function (chunk) {
-                str += chunk;
-            });
+            response.on('data', chunk => responseData += chunk);
 
-            response.on('end', function () {
+            response.on('end', () => {
                 try {
-                    const response = {
+                    const result = {
                         name: "userIsNotMember",
-                        satisfied: JSON.parse(str).tier == null
+                        satisfied: JSON.parse(responseData).tier == null
                     };
-                    resolve(response);
+                    resolve(result);
                 } catch (error) {
                     reject(error);
                 }
             });
         }
 
-        http.request(options, processResponse).end();
+        const request = http.request(options);
 
+        request.on('error', networkError => reject(networkError));
+
+        request.on('response', response => processResponse(response));
+
+        request.end();
     });
 }
 

--- a/nodejs/userIsNotSubscriber.js
+++ b/nodejs/userIsNotSubscriber.js
@@ -1,11 +1,10 @@
-var AWS = require('aws-sdk');
-var http = require('https');
-var kms = new AWS.KMS();
+const AWS = require('aws-sdk');
+const http = require('https');
+const kms = new AWS.KMS();
 
 function userIsNotSubscriber(scGuCookie) {
     return new Promise((resolve, reject) => {
-
-        var options = {
+        const options = {
             host: 'members-data-api.theguardian.com',
             path: '/user-attributes/me/mma-digitalpack',
             headers: {
@@ -14,28 +13,30 @@ function userIsNotSubscriber(scGuCookie) {
         };
 
         function processResponse(response) {
-            var str = '';
+            var responseData = '';
 
-            response.on('data', function (chunk) {
-                str += chunk;
-            });
+            response.on('data', chunk => responseData += chunk);
 
-            response.on('end', function () {
+            response.on('end', () => {
                 try {
-                    const response = {
+                    const result = {
                         name: "userIsNotSubscriber",
-                        satisfied: JSON.parse(str).tier == null
+                        satisfied: JSON.parse(responseData).tier == null
                     };
-                    resolve(response);
+                    resolve(result);
                 } catch (error) {
                     reject(error);
                 }
-
             });
         }
 
-        http.request(options, processResponse).end();
+        const request = http.request(options);
 
+        request.on('error', networkError => reject(networkError));
+
+        request.on('response', response => processResponse(response));
+
+        request.end();
     });
 }
 

--- a/nodejs/userIsValidated.js
+++ b/nodejs/userIsValidated.js
@@ -13,28 +13,29 @@ function userIsValidated(scGuCookie) {
             }
         };
 
-        const request = http.request(options);
-
-        request.on('error', (networkError) => reject(networkError));
-
-        request.on('response', (response) => {
+        function processResponse(response) {
             var responseData = '';
 
             response.on('data', (chunk) => responseData += chunk);
 
             response.on('end', () => {
                 try {
-                    const response = {
+                    const result = {
                         name: "userIsValidated",
                         satisfied: JSON.parse(responseData).user.statusFields.userEmailValidated == true
                     };
-                    resolve(response);
+                    resolve(result);
                 } catch (error) {
                     reject(error);
                 }
             });
+        }
 
-        });
+        const request = http.request(options);
+
+        request.on('error', networkError => reject(networkError));
+
+        request.on('response', response => processResponse(response));
 
         request.end();
     })


### PR DESCRIPTION
Renames local variable `response` to `result` because `processResponse` function already takes an argument named `response`.