### PR TITLE
Make execution ID unique when retrying

### DIFF
--- a/nodejs/startAccountDeletion.js
+++ b/nodejs/startAccountDeletion.js
@@ -33,6 +33,7 @@
 var AWS = require('aws-sdk');
 var stepfunctions = new AWS.StepFunctions();
 var kms = new AWS.KMS();
+const crypto = require("crypto");
 
 exports.handler = (event, context, callback) => {
 
@@ -64,7 +65,7 @@ exports.handler = (event, context, callback) => {
             var params = {
                 stateMachineArn: `arn:aws:states:eu-west-1:942464564246:stateMachine:${process.env.STATE_MACHINE_ARN}`,
                 input: JSON.stringify({stateMachineInput: encryptedStateMachineInput}),
-                name: identityId
+                name: `${identityId}-${randomString()}`
             };
 
             stepfunctions.startExecution(params).promise()
@@ -149,4 +150,8 @@ function buildDotcomeIdentityErrorResponse(message, description) {
         };
 
     return identityErrorResponse;
+}
+
+function randomString() {
+    return crypto.randomBytes(3*4).toString('base64')
 }


### PR DESCRIPTION
Before

![image](https://user-images.githubusercontent.com/13835317/29273463-4662904c-80fc-11e7-9538-fabc2a370d9e.png)

After:

![image](https://user-images.githubusercontent.com/13835317/29273475-500bdc98-80fc-11e7-8950-26b6bb1993b1.png)


If account deletion fails for some reason and the user tries again, then it always fails because the the execution id must be unique:

```
message":"Execution Already Exists: 'arn:aws:states:eu-west-1:942464564246:execution:AccountDeletion-AZO7STL45AT8:18047633'","code":"ExecutionAlreadyExists"
```
So now we attach a random string to the identity number to make it unique.

[API_StartExecution_Errors](http://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html#API_StartExecution_Errors)